### PR TITLE
Add basic cash and stock token flows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,8 @@ allprojects {
         maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-lib-dev' }
         maven { url 'https://jitpack.io' }
         maven { url "https://repo.gradle.org/gradle/libs-releases-local" }
+        maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-tokens-dev' }
+
     }
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
@@ -93,6 +95,7 @@ dependencies {
     // Corda dependencies.
     cordaCompile "$corda_release_group:corda-core:$corda_release_version"
     cordaRuntime "$corda_release_group:corda:$corda_release_version"
+    cordaRuntime "$corda_release_group:corda-node-api:$corda_release_version"
 
     // CorDapp dependencies.
     cordapp project(":tex-exchange-workflows")
@@ -106,6 +109,7 @@ dependencies {
     cordapp "$tokens_release_group:tokens-contracts:$tokens_release_version"
     cordapp "$tokens_release_group:tokens-workflows:$tokens_release_version"
     cordapp "$tokens_release_group:tokens-money:$tokens_release_version"
+
 }
 
 task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
@@ -144,6 +148,15 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         rpcSettings {
             address("localhost:10009")
             adminAddress("localhost:10049")
+        }
+        rpcUsers = [[user: "user1", "password": "test", "permissions": ["ALL"]]]
+    }
+    node {
+        name "O=BankOfEngland,L=London,C=GB"
+        p2pPort 10011
+        rpcSettings {
+            address("localhost:10012")
+            adminAddress("localhost:10052")
         }
         rpcUsers = [[user: "user1", "password": "test", "permissions": ["ALL"]]]
     }

--- a/tex-exchange-contract/build.gradle
+++ b/tex-exchange-contract/build.gradle
@@ -36,6 +36,8 @@ dependencies {
 
     // Token SDK dependencies.
     cordaCompile "$tokens_release_group:tokens-contracts:$tokens_release_version"
+    cordaCompile "$tokens_release_group:tokens-money:$tokens_release_version"
     cordaCompile "$accounts_release_group:accounts-contracts:$accounts_release_version"
+
 }
 

--- a/tex-exchange-contract/src/main/kotlin/com/ccc/types/StockTokenType.kt
+++ b/tex-exchange-contract/src/main/kotlin/com/ccc/types/StockTokenType.kt
@@ -1,0 +1,13 @@
+package com.ccc.types
+
+import com.r3.corda.lib.tokens.contracts.types.TokenType
+
+/**
+ * Wrapper around fixed [TokenType]
+ */
+data class StockTokenType(
+    val ticker: String,
+    override val fractionDigits: Int = 0
+) : TokenType(ticker, fractionDigits) {
+    override fun toString() = tokenIdentifier
+}

--- a/tex-exchange-workflows/build.gradle
+++ b/tex-exchange-workflows/build.gradle
@@ -57,9 +57,10 @@ dependencies {
     cordaCompile project(":tex-exchange-contract")
 
     // Token SDK dependencies.
-    cordaCompile "$tokens_release_group:tokens-money:$tokens_release_version"
     cordaCompile "$tokens_release_group:tokens-workflows:$tokens_release_version"
+    cordaCompile "$tokens_release_group:tokens-money:$tokens_release_version"
     cordaCompile "$accounts_release_group:accounts-workflows:$accounts_release_version"
+
 }
 
 task integrationTest(type: Test, dependsOn: []) {

--- a/tex-exchange-workflows/src/main/kotlin/com/ccc/flow/CashTokenFlow.kt
+++ b/tex-exchange-workflows/src/main/kotlin/com/ccc/flow/CashTokenFlow.kt
@@ -1,0 +1,53 @@
+package com.ccc.flow
+
+import co.paralleluniverse.fibers.Suspendable
+import com.r3.corda.lib.tokens.contracts.states.FungibleToken
+import com.r3.corda.lib.tokens.contracts.utilities.getAttachmentIdForGenericParam
+import com.r3.corda.lib.tokens.contracts.utilities.issuedBy
+import com.r3.corda.lib.tokens.contracts.utilities.of
+import com.r3.corda.lib.tokens.money.FiatCurrency
+import com.r3.corda.lib.tokens.money.GBP
+import com.r3.corda.lib.tokens.workflows.flows.issue.IssueTokensFlow
+import com.r3.corda.lib.tokens.workflows.flows.rpc.IssueTokens
+import com.r3.corda.lib.tokens.workflows.flows.rpc.MoveFungibleTokens
+import net.corda.core.flows.FlowException
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.StartableByRPC
+import net.corda.core.identity.CordaX500Name
+import net.corda.core.identity.Party
+import net.corda.core.transactions.SignedTransaction
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+object CashTokenFlow {
+
+    @StartableByRPC
+    class IssueCashTokenFlow(private val quantity: Double): FlowLogic<SignedTransaction>() {
+        @Suspendable
+        @Throws(FlowException::class)
+        override fun call(): SignedTransaction {
+            val bankOfEngland =
+                serviceHub.networkMapCache.getNodesByLegalName(
+                    CordaX500Name.parse("O=BankOfEngland,L=London,C=GB")).first().legalIdentities.first()
+            if (ourIdentity != bankOfEngland) {
+                throw IllegalArgumentException("Only Bank of England can issue GBP")
+            }
+            val amountOfIssuedToken = quantity of GBP issuedBy bankOfEngland
+            val fungibleToken = FungibleToken(amountOfIssuedToken, ourIdentity, GBP.getAttachmentIdForGenericParam())
+            return subFlow(IssueTokens(listOf(fungibleToken)))
+        }
+    }
+
+    @StartableByRPC
+    class MoveCashTokenFlow(private val quantity: Double, private val recipient: Party): FlowLogic<SignedTransaction>() {
+        @Suspendable
+        @Throws(FlowException::class)
+        override fun call(): SignedTransaction {
+            return subFlow(
+                MoveFungibleTokens(
+                    amount = quantity of GBP,
+                    holder = recipient
+                ))
+        }
+    }
+}

--- a/tex-exchange-workflows/src/main/kotlin/com/ccc/flow/StockTokenFlow.kt
+++ b/tex-exchange-workflows/src/main/kotlin/com/ccc/flow/StockTokenFlow.kt
@@ -1,0 +1,58 @@
+package com.ccc.flow
+
+import co.paralleluniverse.fibers.Suspendable
+import com.ccc.types.StockTokenType
+import com.r3.corda.lib.tokens.contracts.states.FungibleToken
+import com.r3.corda.lib.tokens.contracts.utilities.getAttachmentIdForGenericParam
+import com.r3.corda.lib.tokens.contracts.utilities.issuedBy
+import com.r3.corda.lib.tokens.contracts.utilities.of
+import com.r3.corda.lib.tokens.workflows.flows.rpc.IssueTokens
+import com.r3.corda.lib.tokens.workflows.flows.rpc.MoveFungibleTokens
+import net.corda.core.flows.FlowException
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.StartableByRPC
+import net.corda.core.identity.Party
+import net.corda.core.transactions.SignedTransaction
+
+object StockTokenFlow {
+
+    /**
+     * Self-issue Fungible Stock Token on ledger
+     */
+    @StartableByRPC
+    class SelfIssueStockTokenFlow(private val ticker: String, private val quantity: Int) : FlowLogic<SignedTransaction>() {
+        @Suspendable
+        @Throws(FlowException::class)
+        override fun call(): SignedTransaction {
+            // grab the notary
+            val notary = serviceHub.networkMapCache.notaryIdentities.first()
+
+            // create token type
+            val stockTokenType = StockTokenType(ticker, 0)
+
+            // assign the issuer (self)
+            val selfIssuedStock = stockTokenType issuedBy ourIdentity
+
+            // specify the amount to issue to holder
+            val issueQuantity = quantity of selfIssuedStock
+
+            // create fungible quantity specifying the new owner
+            val fungibleToken = FungibleToken(issueQuantity, ourIdentity, stockTokenType.getAttachmentIdForGenericParam())
+
+            // use built in flow for issuing tokens on ledger
+            return subFlow(IssueTokens(listOf(fungibleToken)))
+        }
+    }
+
+    /**
+     * Move created Fungible Stock tokens to other party
+     */
+    @StartableByRPC
+    class MoveStockTokenFlow(private val ticker: String, private val quantity: Int, private val recipient: Party) : FlowLogic<SignedTransaction>() {
+        @Suspendable
+        @Throws(FlowException::class)
+        override fun call(): SignedTransaction {
+            return subFlow(MoveFungibleTokens(quantity of StockTokenType(ticker), recipient))
+        }
+    }
+}


### PR DESCRIPTION
Adds basic cash and stock token flows.

Cash is FiatCurrency.instanceOf(GBP) from Token SDK.

Stock is FixedTokenType(tokenIdentifier = ticker, fractionDigits = 0).

### Flows
Cash: Issue (throws if not [O=BankOfEngland,L=London,C=GB]), Move
Stock: Issue, Move

### Next
Integrate with Order flows.