### PR TITLE
Order Buy Flow with Tokens - WIP

### DIFF
--- a/tex-exchange-contract/src/main/kotlin/com/ccc/contract/OrderContract2.kt
+++ b/tex-exchange-contract/src/main/kotlin/com/ccc/contract/OrderContract2.kt
@@ -1,0 +1,43 @@
+package com.ccc.contract
+
+import com.ccc.types.StockTokenType
+import com.r3.corda.lib.tokens.contracts.states.FungibleToken
+import net.corda.core.contracts.*
+import net.corda.core.transactions.LedgerTransaction
+import java.security.PublicKey
+
+class OrderContract2 : Contract {
+
+    companion object {
+        @JvmStatic
+        val ORDER_CONTRACT_2_REF = "com.ccc.contract.OrderContract2"
+    }
+
+    interface Commands : CommandData {
+        fun verifyCommand(tx : LedgerTransaction, signers: Set<PublicKey>)
+
+        // Sell Order Open for Sale
+        class List : TypeOnlyCommandData(), Commands {
+            override fun verifyCommand(tx: LedgerTransaction, signers: Set<PublicKey>) {
+                val timeWindow: TimeWindow? = tx.timeWindow
+                requireThat {
+                    "The input state type should be a FungibleToken of StockTokenType" using (tx.inputStates.all { it is FungibleToken && it.amount.token.tokenType is StockTokenType})
+                    "Only two output states should be created when opening a Sell Order" using (1 == tx.outputStates.size)
+                }
+            }
+        }
+
+        class Buy : TypeOnlyCommandData(), Commands {
+            override fun verifyCommand(tx: LedgerTransaction, signers: Set<PublicKey>) {
+//                requireThat {
+//
+//                }
+            }
+        }
+    }
+
+    override fun verify(tx: LedgerTransaction) {
+        val command = tx.commands.requireSingleCommand<Commands>()
+        command.value.verifyCommand(tx, command.signers.toSet())
+    }
+}

--- a/tex-exchange-contract/src/main/kotlin/com/ccc/state/Order.kt
+++ b/tex-exchange-contract/src/main/kotlin/com/ccc/state/Order.kt
@@ -37,6 +37,6 @@ data class Order(
      * Returns a copy the order state with a new buying party.
      */
     fun buy(amount: Amount<Currency>, buyer: Party): Order {
-        return this.copy(price = amount, buyer = buyer)
+        return copy(price = amount, buyer = buyer)
     }
 }

--- a/tex-exchange-contract/src/main/kotlin/com/ccc/state/Order2.kt
+++ b/tex-exchange-contract/src/main/kotlin/com/ccc/state/Order2.kt
@@ -1,0 +1,24 @@
+package com.ccc.state
+
+import com.ccc.contract.OrderContract2
+import net.corda.core.contracts.BelongsToContract
+import net.corda.core.contracts.LinearState
+import net.corda.core.contracts.UniqueIdentifier
+import net.corda.core.identity.AbstractParty
+import net.corda.core.identity.Party
+import java.math.BigDecimal
+import java.time.Instant
+
+@BelongsToContract(OrderContract2::class)
+data class Order2(
+    override val linearId: UniqueIdentifier = UniqueIdentifier(),
+    val ticker: String,
+    val units: Int,
+    val price: BigDecimal,
+    val direction: Direction,
+    val expires: Instant,
+    val seller: Party,
+    val buyers: Set<Party> = mutableSetOf()
+) : LinearState {
+    override val participants: List<AbstractParty> get() = buyers.plus(seller).toList()
+}

--- a/tex-exchange-workflows/src/main/kotlin/com/ccc/flow/BroadcastTransactionFlow.kt
+++ b/tex-exchange-workflows/src/main/kotlin/com/ccc/flow/BroadcastTransactionFlow.kt
@@ -9,13 +9,13 @@ import net.corda.core.utilities.ProgressTracker
 
 class BroadcastTransactionFlow(
     private val stx: SignedTransaction,
-    private val recepients: List<Party>
+    private val recipients: List<Party>
 ) : FlowLogic<Unit>() {
     override val progressTracker = ProgressTracker()
 
     @Suspendable
     override fun call() {
-        val partyIterator = recepients.iterator()
+        val partyIterator = recipients.iterator()
         while (partyIterator.hasNext()) {
             val party = partyIterator.next()
             val otherSideSession = initiateFlow(party)

--- a/tex-exchange-workflows/src/main/kotlin/com/ccc/flow/CashTokenFlow.kt
+++ b/tex-exchange-workflows/src/main/kotlin/com/ccc/flow/CashTokenFlow.kt
@@ -22,7 +22,7 @@ import java.math.RoundingMode
 object CashTokenFlow {
 
     @StartableByRPC
-    class IssueCashTokenFlow(private val quantity: Double): FlowLogic<SignedTransaction>() {
+    class IssueCashTokenFlow(private val quantity: BigDecimal): FlowLogic<SignedTransaction>() {
         @Suspendable
         @Throws(FlowException::class)
         override fun call(): SignedTransaction {
@@ -39,7 +39,7 @@ object CashTokenFlow {
     }
 
     @StartableByRPC
-    class MoveCashTokenFlow(private val quantity: Double, private val recipient: Party): FlowLogic<SignedTransaction>() {
+    class MoveCashTokenFlow(private val quantity: BigDecimal, private val recipient: Party): FlowLogic<SignedTransaction>() {
         @Suspendable
         @Throws(FlowException::class)
         override fun call(): SignedTransaction {

--- a/tex-exchange-workflows/src/main/kotlin/com/ccc/flow/OrderFlow.kt
+++ b/tex-exchange-workflows/src/main/kotlin/com/ccc/flow/OrderFlow.kt
@@ -1,0 +1,176 @@
+package com.ccc.flow
+
+import co.paralleluniverse.fibers.Suspendable
+import com.ccc.contract.OrderContract2
+import com.ccc.state.Direction
+import com.ccc.state.Order2
+import com.ccc.types.StockTokenType
+import com.r3.corda.lib.tokens.contracts.states.FungibleToken
+import com.r3.corda.lib.tokens.contracts.utilities.of
+import com.r3.corda.lib.tokens.money.GBP
+import com.r3.corda.lib.tokens.workflows.flows.rpc.MoveFungibleTokens
+import net.corda.core.contracts.*
+import net.corda.core.flows.*
+import net.corda.core.identity.Party
+import net.corda.core.node.StatesToRecord
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.unwrap
+import java.math.BigDecimal
+import java.time.Instant
+
+object OrderFlow {
+
+    @InitiatingFlow
+    @StartableByRPC
+    class OrderListFlow2(
+        private val ticker: String,
+        private val units: Int,
+        private val price: BigDecimal,
+        private val expires: Instant
+    ) : FlowLogic<SignedTransaction>() {
+
+        @Suspendable
+        override fun call(): SignedTransaction {
+
+            val stock = serviceHub.vaultService.queryBy(FungibleToken::class.java)
+            val stockStateAndRef = stock.states.find { it.state.data.tokenType.tokenIdentifier == ticker }
+                ?: throw IllegalArgumentException("Stock with '$ticker' not found in vault.")
+
+            val quantityOfStockInVault =
+                stock.states.filter { it.state.data.tokenType.tokenIdentifier == ticker }
+                    .sumBy { it.state.data.amount.quantity.toInt() }
+            val sellOrders = serviceHub.vaultService.queryBy(Order2::class.java)
+            val quantityOfStockInSellOrders = sellOrders.states.sumBy { it.state.data.units }
+            val quantityOfAvailableStock = quantityOfStockInVault - quantityOfStockInSellOrders
+            if (units > quantityOfAvailableStock) {
+                throw IllegalArgumentException("Insufficient stock in vault. Found $quantityOfStockInVault units of $ticker.")
+            }
+
+            // create a sell order
+            val inputOrder = Order2(
+                linearId = UniqueIdentifier(),
+                ticker = ticker,
+                units = units,
+                price = price,
+                direction = Direction.SELL,
+                expires = expires,
+                seller = ourIdentity
+//                buyer = null
+            )
+
+            // create a command to list the sell order
+            val commandOrderList = Command(OrderContract2.Commands.List(), ourIdentity.owningKey)
+
+            // create a transaction builder with the following items
+            val txBuilder = TransactionBuilder(notary = serviceHub.networkMapCache.notaryIdentities[0])
+                .withItems(
+                    commandOrderList,
+                    StateAndContract(inputOrder, OrderContract2.ORDER_CONTRACT_2_REF),
+                    TimeWindow.between(serviceHub.clock.instant(), inputOrder.expires)
+                )
+
+            // We check our transaction is valid based on its contracts.
+            txBuilder.verify(serviceHub)
+
+            // We sign the transaction with our private key, making it immutable.
+            val signedInitialTx = serviceHub.signInitialTransaction(txBuilder)
+            val notary = serviceHub.networkMapCache.notaryIdentities.first()
+
+            //Create a FinalityFlow and also BroadcastTx to all the parties
+            val counterPartySessions = serviceHub.networkMapCache.allNodes
+                .filter { it.legalIdentities.first() != inputOrder.seller && it.legalIdentities.first() != notary }
+                .map { it.legalIdentities.first() }.map { initiateFlow(it) }.toSet()
+            return subFlow(FinalityFlow(signedInitialTx, counterPartySessions))
+        }
+    }
+
+    @InitiatedBy(OrderListFlow2::class)
+    class OrderListFlowResponder2(val otherSideSession: FlowSession) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            subFlow(ReceiveFinalityFlow(otherSideSession, statesToRecord = StatesToRecord.ALL_VISIBLE))
+        }
+    }
+
+    @InitiatingFlow
+    @StartableByRPC
+    class OrderBuyFlow2(
+//        private val ticker: String,
+        private val linearId: String
+//        private val units: Int
+    ) : FlowLogic<SignedTransaction>() {
+
+        @Suspendable
+        override fun call(): SignedTransaction {
+
+            // simplified order buy -> buy all stocks in a given order linearId
+
+            val sellOrder = serviceHub.vaultService.queryBy(Order2::class.java).states.firstOrNull { it.state.data.linearId == UniqueIdentifier.fromString(linearId) }
+                ?: throw IllegalArgumentException("Couldn't find order state with $linearId")
+
+            if (sellOrder.state.data.units == 0) {
+                throw IllegalArgumentException("0 units of ${sellOrder.state.data.ticker} available for sale")
+            }
+
+            val gbpInVault = BigDecimal(
+                serviceHub.vaultService.queryBy(FungibleToken::class.java).states.filter {
+                    it.state.data.holder == ourIdentity &&
+                            it.state.data.tokenType.tokenIdentifier == "GBP"
+                }.sumByDouble { it.state.data.amount.quantity.toDouble() }
+            ).movePointLeft(2)
+
+            if (gbpInVault.compareTo(sellOrder.state.data.price.setScale(2).times(BigDecimal(sellOrder.state.data.units))) < 0) {
+                throw IllegalArgumentException("Order price: ${sellOrder.state.data.price.setScale(2).times(BigDecimal(sellOrder.state.data.units))}, available in vault: $gbpInVault")
+            }
+
+            val txBuilder = TransactionBuilder(serviceHub.networkMapCache.notaryIdentities[0])
+
+            txBuilder.addInputState(sellOrder)
+
+            txBuilder.addOutputState(sellOrder.state.data.copy(
+                units = 0,
+                buyers = sellOrder.state.data.buyers.plus(ourIdentity)
+            ))
+
+            txBuilder.addCommand(Command(OrderContract2.Commands.Buy(),
+                sellOrder.state.data.participants.map { it.owningKey } + ourIdentity.owningKey))
+            txBuilder.verify(serviceHub)
+
+//            val notary = serviceHub.networkMapCache.notaryIdentities.first()
+            val everyoneElse = sellOrder.state.data.participants
+            val signedInitialTx = serviceHub.signInitialTransaction(txBuilder)
+
+            //Create a FinalityFlow and also BroadcastTx to all the parties
+            val counterPartySessions = everyoneElse.map { initiateFlow(it as Party) }
+            //Send GBP to seller
+            subFlow(MoveFungibleTokens(sellOrder.state.data.price.times(BigDecimal(sellOrder.state.data.units)) of GBP, sellOrder.state.data.seller))
+            //Send sellOrder state to counter party seller -> from this the seller can derive the units
+            counterPartySessions.forEach { it.send(sellOrder.state.data) }
+            val signedByAllTx = subFlow(CollectSignaturesFlow(signedInitialTx, counterPartySessions))
+            return subFlow(FinalityFlow(signedByAllTx, counterPartySessions))
+        }
+    }
+
+    @InitiatedBy(OrderBuyFlow2::class)
+    class OrderBuyFlowResponder2(val flowSession: FlowSession) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            val signedTransactionFlow = object : SignTransactionFlow(flowSession) {
+                override fun checkTransaction(stx: SignedTransaction) = requireThat {
+                    // TODO: Add additional checks here
+                }
+            }
+
+            //Receive sell order state data from buyer
+            val sellOrder = flowSession.receive<Order2>().unwrap { it }
+
+            //Send stock tokens to seller
+            subFlow(MoveFungibleTokens(sellOrder.units of StockTokenType(sellOrder.ticker), flowSession.counterparty))
+
+            subFlow(signedTransactionFlow)
+
+            subFlow(ReceiveFinalityFlow(flowSession, statesToRecord = StatesToRecord.ALL_VISIBLE))
+        }
+    }
+}


### PR DESCRIPTION
Needs rebase and testing

## Demo Commands

`./gradlew clean deployNodes`

`./build/nodes/runnodes/`

Ensure Notary, PartyA, PartyB and BankOfEngland nodes are running. If not, cd into `./build/nodes/[Node Name Here]` and `java -jar corda.jar`

PartyA: Self issue stock tokens and list order
`flow start SelfIssueStockTokenFlow ticker: GOOG, quantity: 1000`
`flow start OrderListFlow2 ticker: GOOG, units: 10, price: 25, expires: "2019-12-28T18:30:00.000Z"`

Query PartyA vault for stock tokens
`run vaultQuery contractStateType: com.r3.corda.lib.tokens.contracts.states.FungibleToken`

Query PartyA and/or B vault(s) for listed order state
`run vaultQuery contractStateType: com.ccc.state.Order2`

PartyB: Attempt to buy order - should fail with exception (insufficient funds)
`flow start OrderBuyFlow2 linearId: [Order linearId]`

Issue GBP from BankOfEngland and move to PartyB
`flow start IssueCashTokenFlow quantity: 1000.00`
`flow start MoveCashTokenFlow quantity: 250.00, recipient: PartyB`

Query PartyB vault for GBP
`run vaultQuery contractStateType: com.r3.corda.lib.tokens.contracts.states.FungibleToken`

PartyB: Buy order with funds
`flow start OrderBuyFlow2 linearId: [Order Id]`

Query PartyB vault for stock tokens and observe GBP tokens have moved
`run vaultQuery contractStateType: com.r3.corda.lib.tokens.contracts.states.FungibleToken`

Query PartyA vault for GBP tokens and reduced # of stock tokens
`run vaultQuery contractStateType: com.r3.corda.lib.tokens.contracts.states.FungibleToken`